### PR TITLE
Update apm.py

### DIFF
--- a/apm.py
+++ b/apm.py
@@ -24,7 +24,8 @@ if ver==2:  # Python 2
         '''Send a request to the server \n \
            server = address of server \n \
            app      = application name \n \
-           aline  = line to send to server \n'''
+           aline  = line to send to server \n \
+           disp = Print output \n'''
         try:
             # Web-server URL address
             url_base = string.strip(server) + '/online/apm_line.php'

--- a/apm.py
+++ b/apm.py
@@ -309,11 +309,12 @@ if ver==2:  # Python 2
 
 else:       # Python 3+
     
-    def cmd(server,app,aline):
+    def cmd(server,app,aline, disp=True):
         '''Send a request to the server \n \
            server = address of server \n \
            app      = application name \n \
-           aline  = line to send to server \n'''
+           aline  = line to send to server \n \
+           disp = Print output \n'''
         try:
             # Web-server URL address
             url_base = server.strip() + '/online/apm_line.php'
@@ -331,7 +332,8 @@ else:       # Python 3+
                     if not char:
                         break
                     elif char == '\n':
-                        print(line)
+                        if disp:
+                            print(line)
                         line = ''
                     else:
                         line += char

--- a/apm.py
+++ b/apm.py
@@ -20,7 +20,7 @@ else:       # Python 3+
 
 if ver==2:  # Python 2
 
-    def cmd(server, app, aline):
+    def cmd(server, app, aline, disp=True):
         '''Send a request to the server \n \
            server = address of server \n \
            app      = application name \n \
@@ -40,7 +40,8 @@ if ver==2:  # Python 2
                     if not char:
                         break
                     elif char == '\n':
-                        print(line)
+                        if disp: 
+                            print(line)
                         line = ''
                     else:
                         line += char


### PR DESCRIPTION
Add option to not print output from APM cmd. In a perfect world, I think it might be best to adjust the return value of method to return a tuple of `(response, output)` so the caller can do what they will with the output, or something similar, but that will likely cause a fair amount of refactoring.

This change should keep the default behavior while allowing to opt out from printing input, for example when running APM from Gekko. I haven't spent an inordinate amount of time thinking over this change, so feedback is certainly welcome :)